### PR TITLE
Fix keras version error on Tacotron2_and_WaveNet_text_to_speech_demo.ipynb

### DIFF
--- a/Tacotron2_and_WaveNet_text_to_speech_demo.ipynb
+++ b/Tacotron2_and_WaveNet_text_to_speech_demo.ipynb
@@ -94,6 +94,7 @@
       "source": [
         "# Install dependencies\n",
         "! pip install -q -U \"tensorflow<=1.9.0\"\n",
+        "! pip install -q -U \"keras==2.2.4\"\n",
         "! pip install -q -U \"numpy<1.16\"\n",
         "! pip install -q -U \"pysptk<=0.1.14\"\n",
         "\n",


### PR DESCRIPTION
# Keras import error
The error was occured when I try to do "Tacotron2_and_WaveNet_text_to_speech_demo.ipynb".

**script**
```
from train import build_model
```

**error**
```
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
/usr/local/lib/python3.6/dist-packages/keras/__init__.py in <module>()
      2 try:
----> 3     from tensorflow.keras.layers.experimental.preprocessing import RandomRotation
      4 except ImportError:

ModuleNotFoundError: No module named 'tensorflow.keras.layers.experimental'
During handling of the above exception, another exception occurred:

ImportError                               Traceback (most recent call last)


2 frames

/usr/local/lib/python3.6/dist-packages/keras/__init__.py in <module>()
      4 except ImportError:
      5     raise ImportError(
----> 6         'Keras requires TensorFlow 2.2 or higher. '
      7         'Install TensorFlow via `pip install tensorflow`')
      8 

ImportError: Keras requires TensorFlow 2.2 or higher. Install TensorFlow via `pip install tensorflow`
---------------------------------------------------------------------------
NOTE: If your import is failing due to a missing package, you can
manually install dependencies using either !pip or !apt.

To view examples of installing some common dependencies, click the
"Open Examples" button below.
---------------------------------------------------------------------------
```

I think the version of keras preinstalled in Google Colab cause the error, so I added `! pip install -q -U "keras==2.2.4"` to downgrade the keras version.
After that, the notebook will work without error.

cf) 
**default keras version**
```
import keras
print(keras.__version__)
```
`2.4.3`